### PR TITLE
chore: improve sync-template workflow (fixed branch name + conflict file list)

### DIFF
--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -11,6 +11,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      BRANCH_NAME: sync-template
 
     steps:
       - name: 🛎 Checkout
@@ -51,7 +53,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          EXISTING_PR=$(gh pr list --search "Sync template" --state open --json number --jq '.[0].number')
+          EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --state open --json number --jq '.[0].number')
           if [ -n "$EXISTING_PR" ]; then
             echo "existing_pr=true" >> $GITHUB_OUTPUT
             echo "::notice::既存のPR #$EXISTING_PR があるためスキップします"
@@ -62,8 +64,8 @@ jobs:
       - name: 🌿 Create sync branch
         if: steps.check_updates.outputs.has_updates == 'true' && steps.check_pr.outputs.existing_pr == 'false'
         run: |
-          BRANCH_NAME="sync-template-$(date +%Y%m%d-%H%M%S)"
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          # 既存PRがないことは確認済みなので、残っているリモートブランチは安全に削除できる
+          git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
           git checkout -b "$BRANCH_NAME"
 
       - name: 🔄 Merge template changes
@@ -110,30 +112,41 @@ jobs:
           git merge --abort || true
           git merge --no-commit --no-ff template/main || true
 
-          # Commit with conflict markers if there are conflicts
+          # コンフリクトしたファイル一覧をPR本文用に保存
+          CONFLICTED_FILES=$(git diff --name-only --diff-filter=U | sort)
+
+          # コンフリクトマーカーを含めてcommit
           git add .
           git commit -m "Merge template updates (with conflicts)" || true
 
           git push origin "$BRANCH_NAME"
+
+          # PR本文をheredocで生成（コンフリクトファイル一覧を箇条書きで埋め込む）
+          {
+            echo "This PR attempts to sync the latest changes from the [ts-template](https://github.com/manaten/ts-template) repository."
+            echo ""
+            echo "## ⚠️ Conflicts detected"
+            echo ""
+            echo "The following files have conflict markers and need manual resolution:"
+            echo ""
+            echo "$CONFLICTED_FILES" | sed 's|^|- `|; s|$|`|'
+            echo ""
+            echo "Resolve them by checking out this branch, fixing the conflicts, and pushing back."
+            echo ""
+            echo "## Changes"
+            echo "This PR includes the following commits from the template:"
+            echo ""
+            echo '```'
+            git log --oneline HEAD~1...template/main | head -10
+            echo '```'
+            echo ""
+            echo "---"
+            echo "🤖 This PR was automatically created by the sync-template workflow."
+          } > /tmp/pr_body.md
+
           gh pr create \
             --title "⚠️ Sync template updates (with conflicts)" \
-            --body "This PR attempts to sync the latest changes from the [ts-template](https://github.com/manaten/ts-template) repository.
-
-          ## ⚠️ Conflicts detected
-          The merge resulted in conflicts. Please resolve the conflicts manually:
-
-          1. Check out this branch
-          2. Resolve conflicts in the affected files
-          3. Commit the resolved changes
-          4. Push to this branch
-
-          ## Changes
-          This PR includes the following commits from the template:
-
-          $(git log --oneline HEAD...template/main | head -10)
-
-          ---
-          🤖 This PR was automatically created by the sync-template workflow." \
+            --body-file /tmp/pr_body.md \
             --base main \
             --head "$BRANCH_NAME"
 


### PR DESCRIPTION
## Summary

sync-template workflow の運用改善。PR #73 のレビュー後に出てきた「ブランチが散らかる」「コンフリクト時の差分情報がほしい」という課題に対応する。

### 1. ブランチ名固定 (`sync-template`)
これまで `sync-template-YYYYMMDD-HHMMSS` でタイムスタンプ付き使い捨てブランチを作っていたため、リモートにブランチが累積していた。固定名にして reuse する形に変更:

- 既存 PR があればスキップ（従来通り）
- 既存 PR が無く、リモートに古いブランチが残っていれば削除してから作り直す

### 2. 既存 PR チェックを branch ベースに
タイトル substring (`--search "Sync template"`) は他の PR を誤マッチする可能性があったため、`--head <branch>` で厳密にチェックする方式に変更。

### 3. コンフリクト時の PR 本文にファイル一覧を追加
コンフリクトファイル名が PR 本文に箇条書きで出るようにした。事前にどこを直せばいいかが分かる:

```
## ⚠️ Conflicts detected

The following files have conflict markers and need manual resolution:

- `eslint.config.mjs`
- `package.json`

Resolve them by checking out this branch, fixing the conflicts, and pushing back.
```

heredoc で本文を組み立てるため `gh pr create --body-file` に切り替え。

## Test plan
- [x] YAML 構文チェック (`python3 -c "import yaml; ..."`)
- [ ] 次回 cron 実行時の挙動を観察（または `workflow_dispatch` で手動実行）

---
_Generated by [Claude Code](https://claude.ai/code/session_018aZJ96DAFtiX7t3tLGSCek)_