### PR TITLE
fix: workflow ファイル変更時の sync-template を fail-fast にする

### DIFF
--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -19,7 +19,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # workflow ファイル (.github/workflows/*) の更新には `workflow` スコープを持つ
+          # PAT が必要なので、SYNC_TEMPLATE_TOKEN があればそれを優先して使う。
+          token: ${{ secrets.SYNC_TEMPLATE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: 🔧 Configure Git
         run: |
@@ -51,7 +53,7 @@ jobs:
         if: steps.check_updates.outputs.has_updates == 'true'
         id: check_pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SYNC_TEMPLATE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --state open --json number --jq '.[0].number')
           if [ -n "$EXISTING_PR" ]; then
@@ -80,7 +82,7 @@ jobs:
         id: create_pr
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SYNC_TEMPLATE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           git push origin "$BRANCH_NAME"
           gh pr create \
@@ -107,7 +109,7 @@ jobs:
         id: create_pr_conflict
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SYNC_TEMPLATE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           git merge --abort || true
           git merge --no-commit --no-ff template/main || true
@@ -157,7 +159,7 @@ jobs:
       - name: 🧹 Cleanup on failure
         if: failure() || steps.create_pr.outcome == 'failure' || steps.create_pr_conflict.outcome == 'failure'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SYNC_TEMPLATE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           if [ -n "$BRANCH_NAME" ]; then
             git push origin --delete "$BRANCH_NAME" 2>/dev/null || true

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -19,9 +19,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          # workflow ファイル (.github/workflows/*) の更新には `workflow` スコープを持つ
-          # PAT が必要なので、SYNC_TEMPLATE_TOKEN があればそれを優先して使う。
-          token: ${{ secrets.SYNC_TEMPLATE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🔧 Configure Git
         run: |
@@ -49,11 +47,36 @@ jobs:
             echo "has_updates=false" >> $GITHUB_OUTPUT
           fi
 
+      # GITHUB_TOKEN は `.github/workflows/` 配下を更新する権限を持たないため、
+      # workflow ファイルに変更が含まれる場合は自動 push が必ず失敗する。
+      # そのまま進めると後段の push で失敗して通知される設計だが、原因が
+      # 分かりにくいので事前に検出して明示的なメッセージで失敗させる。
+      - name: 🔍 Check workflow file changes
+        if: steps.check_updates.outputs.has_updates == 'true'
+        run: |
+          WORKFLOW_CHANGES=$(git diff --name-only HEAD..template/main -- .github/workflows/)
+          if [ -n "$WORKFLOW_CHANGES" ]; then
+            {
+              echo "::error::Template に .github/workflows/ 配下の変更が含まれているため自動同期できません。ローカルで手動マージ・push してください。"
+              echo "変更されたワークフローファイル:"
+              echo "$WORKFLOW_CHANGES" | sed 's/^/  - /'
+              echo ""
+              echo "手動同期手順:"
+              echo "  git remote add template https://github.com/manaten/ts-template.git  # 未追加なら"
+              echo "  git fetch template main"
+              echo "  git checkout -b sync-template"
+              echo "  git merge template/main"
+              echo "  # コンフリクトを解消したら"
+              echo "  git push origin sync-template"
+            } >&2
+            exit 1
+          fi
+
       - name: 🔍 Check existing PR
         if: steps.check_updates.outputs.has_updates == 'true'
         id: check_pr
         env:
-          GH_TOKEN: ${{ secrets.SYNC_TEMPLATE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --state open --json number --jq '.[0].number')
           if [ -n "$EXISTING_PR" ]; then
@@ -82,7 +105,7 @@ jobs:
         id: create_pr
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.SYNC_TEMPLATE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git push origin "$BRANCH_NAME"
           gh pr create \
@@ -109,7 +132,7 @@ jobs:
         id: create_pr_conflict
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.SYNC_TEMPLATE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git merge --abort || true
           git merge --no-commit --no-ff template/main || true
@@ -159,9 +182,18 @@ jobs:
       - name: 🧹 Cleanup on failure
         if: failure() || steps.create_pr.outcome == 'failure' || steps.create_pr_conflict.outcome == 'failure'
         env:
-          GH_TOKEN: ${{ secrets.SYNC_TEMPLATE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ -n "$BRANCH_NAME" ]; then
             git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
             echo "::warning::PR作成に失敗したためブランチ $BRANCH_NAME を削除しました"
           fi
+
+      # create_pr / create_pr_conflict は `continue-on-error: true` のため、
+      # 失敗してもジョブ自体は success になってしまい通知されない。
+      # ここで明示的に失敗させて Actions の失敗通知が飛ぶようにする。
+      - name: ❌ Fail job if PR creation failed
+        if: steps.create_pr.outcome == 'failure' || steps.create_pr_conflict.outcome == 'failure'
+        run: |
+          echo "::error::PR の作成または push に失敗しました。ログを確認し、必要に応じて手動で同期してください。"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -1,16 +1,3 @@
 # ts-node-cli-template
 
 manaten's ts-node cli script tempalate.
-
-## Sync Template ワークフローについて
-
-このテンプレートには、`ts-template` の更新を取り込む `sync-template` ワークフローが含まれています。
-
-`.github/workflows/` 配下のファイル更新を含むテンプレート変更を取り込みたい場合、デフォルトの `GITHUB_TOKEN` ではワークフローファイルを変更できないため、別途 PAT (Personal Access Token) が必要です。
-
-### セットアップ手順
-
-1. GitHub の Settings > Developer settings > Personal access tokens から、`workflow` スコープを持つ Fine-grained または Classic PAT を作成
-2. リポジトリの Settings > Secrets and variables > Actions で `SYNC_TEMPLATE_TOKEN` という名前で登録
-
-`SYNC_TEMPLATE_TOKEN` が未設定の場合は `GITHUB_TOKEN` にフォールバックしますが、ワークフローファイルを含む変更時に push が失敗します。

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # ts-node-cli-template
 
 manaten's ts-node cli script tempalate.
+
+## Sync Template ワークフローについて
+
+このテンプレートには、`ts-template` の更新を取り込む `sync-template` ワークフローが含まれています。
+
+`.github/workflows/` 配下のファイル更新を含むテンプレート変更を取り込みたい場合、デフォルトの `GITHUB_TOKEN` ではワークフローファイルを変更できないため、別途 PAT (Personal Access Token) が必要です。
+
+### セットアップ手順
+
+1. GitHub の Settings > Developer settings > Personal access tokens から、`workflow` スコープを持つ Fine-grained または Classic PAT を作成
+2. リポジトリの Settings > Secrets and variables > Actions で `SYNC_TEMPLATE_TOKEN` という名前で登録
+
+`SYNC_TEMPLATE_TOKEN` が未設定の場合は `GITHUB_TOKEN` にフォールバックしますが、ワークフローファイルを含む変更時に push が失敗します。


### PR DESCRIPTION
## 背景

派生リポジトリ (KabuBot) で sync-template ワークフロー実行時、以下のエラーで push が失敗していた:

```
! [remote rejected] sync-template-... -> sync-template-... (refusing to allow a GitHub App to create or update workflow `.github/workflows/sync-template.yml` without `workflows` permission)
```

`GITHUB_TOKEN` は `.github/workflows/` 配下のファイルを更新する権限を持たないため、テンプレート側に workflow ファイル変更が含まれると push が必ず失敗する。さらに `continue-on-error: true` によりジョブ全体は success 判定となり、失敗に気付けない状態だった。

## 方針

すべての派生リポジトリに PAT 設定を要求するのは負担が大きいため、PAT 方式は採らず、**失敗を明示化して手動同期に誘導する** 方針とした。

## 変更内容

- **`🔍 Check workflow file changes` ステップを追加**: テンプレートの diff に `.github/workflows/` の変更があれば、merge を試みる前に明示的に失敗。手動同期コマンドをログに出力する
- **`❌ Fail job if PR creation failed` ステップを追加**: `create_pr` / `create_pr_conflict` が `continue-on-error: true` で握りつぶされていた失敗を、ジョブ全体の失敗として表面化させ、Actions の失敗通知が飛ぶようにする

## 動作

- テンプレートに workflow 変更が含まれる場合: ジョブが赤くなり、ログに手動同期手順が表示される
- それ以外の場合: 従来通り自動で PR が作成される
- PR 作成や push が他の理由で失敗した場合も、ジョブが赤くなって通知される

## Test plan

- [ ] 派生リポジトリで `workflow_dispatch` から実行し、workflow ファイル更新を含むテンプレート変更がある場合にジョブが失敗し、ログに手動同期手順が出ることを確認
- [ ] workflow ファイル変更を含まないテンプレート更新では従来通り PR が作成されることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXysYNFKByCAqv6VfhSYwi)_